### PR TITLE
Clear interceptors on configure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,10 @@ class Superlogin extends EventEmitter {
 			return Promise.reject(response);
 		};
 
+		// clear interceptors from a previous configure call
+		this._http.interceptors.request.handlers = [];
+		this._http.interceptors.response.handlers = [];
+		
 		this._http.interceptors.request.use(request.bind(this));
 		this._http.interceptors.response.use(null, responseError.bind(this));
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,6 @@ class Superlogin extends EventEmitter {
 		this._config = {};
 		this._refreshCB = this.refresh;
 		this.refreshInProgress = false;
-		this._http = axios.create();
 	}
 
 	configure(config = {}) {
@@ -68,6 +67,10 @@ class Superlogin extends EventEmitter {
 	}
 
 	_httpInterceptor() {
+		// Create fresh axios instance, forgetting
+		// interceptors from a previous configure call
+		this._http = _axios2.default.create();
+		
 		const request = req => {
 			const config = this.getConfig();
 			const session = this.getSession();
@@ -98,10 +101,6 @@ class Superlogin extends EventEmitter {
 			}
 			return Promise.reject(response);
 		};
-
-		// clear interceptors from a previous configure call
-		this._http.interceptors.request.handlers = [];
-		this._http.interceptors.response.handlers = [];
 		
 		this._http.interceptors.request.use(request.bind(this));
 		this._http.interceptors.response.use(null, responseError.bind(this));


### PR DESCRIPTION
Currently when configure is called multiple times there will be multiple request interceptors, which usually means the checkRefresh is called  multiple times uncecesarily. This also solves: https://github.com/micky2be/superlogin-client/issues/17
