### PR TITLE
Enable install from github in jspm

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "eslint-config-airbnb-base": "^9.0.0",
     "eslint-plugin-import": "^2.0.1",
     "pre-commit": "^1.1.3"
+  },
+  "jspm": {
+    "registry": "npm"
   }
 }


### PR DESCRIPTION
By declaring it's a package build for npm context.
This allows us to sometimes temporarily work with our own fork from github. 