### PR TITLE
Delete session on unauthorized refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "eslint-config-airbnb-base": "^9.0.0",
     "eslint-plugin-import": "^2.0.1",
     "pre-commit": "^1.1.3"
+  },
+  "jspm": {
+    "registry": "npm"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
     "eslint-config-airbnb-base": "^9.0.0",
     "eslint-plugin-import": "^2.0.1",
     "pre-commit": "^1.1.3"
-  },
-  "jspm": {
-    "registry": "npm"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -100,22 +100,22 @@ class Superlogin extends EventEmitter2 {
 			});
 		};
 
-		const responseError = response => {
+		const responseError = error => {
 			const config = this.getConfig();
 
-			// if there is not config obj in in the response it means we cannot check the endpoints.
+			// if there is not config obj in in the error it means we cannot check the endpoints.
 			// This happens for example if there is no connection at all because axion just forwards the raw error.
-			if (!response || !response.config) {
-				return Promise.reject(response);
+			if (!error || !error.config) {
+				return Promise.reject(error);
 			}
 
 			// If there is an unauthorized error from one of our endpoints and we are logged in...
-			if (checkEndpoint(response.config.url, config.endpoints) &&
-				response.status === 401 && this.authenticated()) {
+			if (checkEndpoint(error.config.url, config.endpoints) &&
+				error.response.status === 401 && this.authenticated()) {
 				debug.warn('Not authorized');
 				this._onLogout('Session expired');
 			}
-			return Promise.reject(response);
+			return Promise.reject(error);
 		};
 		// clear interceptors from a previous configure call
 		this._http.interceptors.request.eject(this._httpRequestInterceptor);


### PR DESCRIPTION
The session wasn't deleted after refresh resulted in a unauthorized response. It looks like this was the result of changes in Axios (like: #25). The response status was moved, into a response object. 
See: https://github.com/micky2be/superlogin-client/issues/36