### PR TITLE
Dispatch better error when authorization popup is blocked

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -495,6 +495,11 @@ class Superlogin extends EventEmitter2 {
 			options.windowName = options.windowTitle ||	'Social Login';
 			options.windowOptions = options.windowOptions || 'location=0,status=0,width=800,height=600';
 			const _oauthWindow = window.open(url, options.windowName, options.windowOptions);
+
+			if (!_oauthWindow) {
+				reject({ error: 'Authorization popup blocked' });
+			}
+
 			const _oauthInterval = setInterval(() => {
 				if (_oauthWindow.closed) {
 					clearInterval(_oauthInterval);


### PR DESCRIPTION
Regarding #44. If the authorization popup is blocked `window.open` returns `null`.