### PR TITLE
Fix register type signature

### DIFF
--- a/superlogin-client.d.ts
+++ b/superlogin-client.d.ts
@@ -18,7 +18,7 @@ interface SuperLoginClient extends EventEmitter2.emitter {
 	checkRefresh: () => void;
 	checkExpired: () => void;
 	login: (login: { username: string, password: string }) => Promise<any>;
-	register: (register: { username: string, name?: string, email?: string, password: string, confirmPassword: string, [key: string]: any }) => Promise<any>;
+	register: (register: { username?: string, name?: string, email?: string, password: string, confirmPassword: string, [key: string]: any }) => Promise<any>;
 	logout: (message?: string) => Promise<any>;
 	logoutAll: (message?: string) => Promise<any>;
 	logoutOthers: () => Promise<any>;


### PR DESCRIPTION
Since SuperLogin allows using the email as username, the username property must also be optional.

See https://github.com/colinskow/superlogin/blob/287d10193e2517c174c3ceef0d8397f57f95f01f/config.example.js#L43