### PR TITLE
Using url-parse to parse host

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "axios": "~0.14.0",
     "debug": "~2.2.0",
-    "eventemitter2": "^2.1.3"
+    "eventemitter2": "^2.1.3",
+    "url-parse": "^1.1.8"
   },
   "devDependencies": {
     "babel-cli": "~6.18.0",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "eslint-config-airbnb-base": "^9.0.0",
     "eslint-plugin-import": "^2.0.1",
     "pre-commit": "^1.1.3"
+  },
+  "jspm": {
+    "registry": "npm"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
     "eslint-config-airbnb-base": "^9.0.0",
     "eslint-plugin-import": "^2.0.1",
     "pre-commit": "^1.1.3"
-  },
-  "jspm": {
-    "registry": "npm"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import _debug from 'debug';
 import { EventEmitter2 } from 'eventemitter2';
+import URL from 'url-parse';
 
 const debug = {
 	log: _debug('superlogin:log'),
@@ -15,9 +16,8 @@ function capitalizeFirstLetter(string) {
 }
 
 function parseHostFromUrl(url) {
-	const parser = window.document.createElement('a');
-	parser.href = url;
-	return parser.host;
+	const parsedURL = new URL(url);
+	return parsedURL.host;
 }
 
 function checkEndpoint(url, endpoints) {


### PR DESCRIPTION
Instead of using a `a` element, making it work with relative url's on IE11 and allowing usage inside web worker. See: #40