### PR TITLE
Custom timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ var config = {
   // token. For example if a token was issued at 1pm and expires at 2pm, and the threshold is 0.5, the token will
   // automatically refresh after 1:30pm. When authenticated, the token expiration is automatically checked on every
   // request. You can do this manually by calling superlogin.checkRefresh(). Default: 0.5
-  refreshThreshold: 0.5
+  refreshThreshold: 0.5,
+  // The number of milliseconds before a request times out
+  // If the request takes longer than `timeout`, the request will be aborted.
+  // Default is 0, meaning it won't timeout.
+  timeout: 0
 };
 ```
 Now let's import SuperLogin and configure it...

--- a/config.example.js
+++ b/config.example.js
@@ -21,5 +21,9 @@ var config = {
   // token. For example if a token was issued at 1pm and expires at 2pm, and the threshold is 0.5, the token will
   // automatically refresh after 1:30pm. When authenticated, the token expiration is automatically checked on every
   // request. You can do this manually by calling superlogin.checkRefresh(). Default: 0.5
-  refreshThreshold: 0.5
+  refreshThreshold: 0.5,
+  // The number of milliseconds before a request times out
+  // If the request takes longer than `timeout`, the request will be aborted.
+  // Default is 0, meaning it won't timeout.
+  timeout: 0
 };

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "eslint-config-airbnb-base": "^9.0.0",
     "eslint-plugin-import": "^2.0.1",
     "pre-commit": "^1.1.3"
+  },
+  "jspm": {
+    "registry": "npm"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
     "eslint-config-airbnb-base": "^9.0.0",
     "eslint-plugin-import": "^2.0.1",
     "pre-commit": "^1.1.3"
-  },
-  "jspm": {
-    "registry": "npm"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,8 @@ class Superlogin extends EventEmitter2 {
 	configure(config = {}) {
 		if (config.serverUrl) {
 			this._http = axios.create({
-				baseURL: config.serverUrl
+				baseURL: config.serverUrl,
+				timeout: config.timeout
 			});
 		}
 
@@ -92,6 +93,7 @@ class Superlogin extends EventEmitter2 {
 			config.endpoints.push(defaultEndpoint);
 		}
 		config.providers = config.providers || [];
+		config.timeout = config.timeout || 0;
 
 		if (!isStorageAvailable()) {
 			this.storage = memoryStorage;


### PR DESCRIPTION
Currently the default timeout of Axios is used, which is 0, which means it can take a very long before it gives up a login request for example. This option allows overriding this timeout configuration. 

Also see: https://github.com/mzabriskie/axios#request-config
Default: https://github.com/mzabriskie/axios/blob/master/lib/defaults.js#L65