### PR TITLE
Handle no response

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "eslint-config-airbnb-base": "^9.0.0",
     "eslint-plugin-import": "^2.0.1",
     "pre-commit": "^1.1.3"
+  },
+  "jspm": {
+    "registry": "npm"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
     "eslint-config-airbnb-base": "^9.0.0",
     "eslint-plugin-import": "^2.0.1",
     "pre-commit": "^1.1.3"
-  },
-  "jspm": {
-    "registry": "npm"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -362,7 +362,7 @@ class Superlogin extends EventEmitter2 {
 			})
 			.catch(err => {
 				this._onLogout(msg || 'Logged out');
-				if (!err.response || (err.response && err.response.data.status !== 401)) {
+				if (!err.response || err.response.data.status !== 401) {
 					throw parseError(err);
 				}
 			});
@@ -376,7 +376,7 @@ class Superlogin extends EventEmitter2 {
 			})
 			.catch(err => {
 				this._onLogout(msg || 'Logged out');
-				if (!err.response || (err.response && err.response.data.status !== 401)) {
+				if (!err.response || err.response.data.status !== 401) {
 					throw parseError(err);
 				}
 			});

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ class Superlogin extends EventEmitter2 {
 
 			// If there is an unauthorized error from one of our endpoints and we are logged in...
 			if (checkEndpoint(error.config.url, config.endpoints) &&
-				error.response.status === 401 && this.authenticated()) {
+				error.response &&	error.response.status === 401 && this.authenticated()) {
 				debug.warn('Not authorized');
 				this._onLogout('Session expired');
 			}
@@ -362,7 +362,7 @@ class Superlogin extends EventEmitter2 {
 			})
 			.catch(err => {
 				this._onLogout(msg || 'Logged out');
-				if (err.response.data.status !== 401) {
+				if (!err.response || (err.response && err.response.data.status !== 401)) {
 					throw parseError(err);
 				}
 			});
@@ -376,7 +376,7 @@ class Superlogin extends EventEmitter2 {
 			})
 			.catch(err => {
 				this._onLogout(msg || 'Logged out');
-				if (err.response.data.status !== 401) {
+				if (!err.response || (err.response && err.response.data.status !== 401)) {
 					throw parseError(err);
 				}
 			});

--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ class Superlogin extends EventEmitter2 {
 
 			// If there is an unauthorized error from one of our endpoints and we are logged in...
 			if (checkEndpoint(error.config.url, config.endpoints) &&
-				error.response &&	error.response.status === 401 && this.authenticated()) {
+				error.response && error.response.status === 401 && this.authenticated()) {
 				debug.warn('Not authorized');
 				this._onLogout('Session expired');
 			}


### PR DESCRIPTION
For example timeouts and network errors. In these cases the generated Error instance doesn't contain a response object. 