### PR TITLE
verifyEmail should be confirmEmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Link a provider using an access_token obtained by the client. Returns a promise.
 ##### `superlogin.unlink(provider)`
 Unlinks the specified provider from the user's account. Returns a promise.
 
-##### `superlogin.verifyEmail(token)`
+##### `superlogin.confirmEmail(token)`
 Verifies the user's email with the SuperLogin server, using the specified token. Returns a promise. Authentication is not required. The token will be a URL parameter passed in when the user clicks on the confirmation link in the email sent by the system. Your app needs to manually extract the token from the URL and pass it in here.
 
 ##### `superlogin.forgotPassword(email)`

--- a/src/index.js
+++ b/src/index.js
@@ -472,11 +472,11 @@ class Superlogin extends EventEmitter2 {
 		return Promise.reject({ error: 'Authentication required' });
 	}
 
-	verifyEmail(token) {
+	confirmEmail(token) {
 		if (!token || typeof token !== 'string') {
 			return Promise.reject({ error: 'Invalid token' });
 		}
-		return this._http.get(`${this._config.baseUrl}/verify-email/${token}`)
+		return this._http.get(`${this._config.baseUrl}/confirm-email/${token}`)
 			.then(res => res.data)
 			.catch(err => {
 				throw parseError(err);


### PR DESCRIPTION
I just noticed that the verifyEmail command does not work. The correct route is /auth/confirm-email and not /auth/verify-email:
https://github.com/colinskow/superlogin#get-confirm-emailtoken

The second commit also renames the verifyEmail method to confirmEmail.